### PR TITLE
Improve Froala detection

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -1380,12 +1380,15 @@
       24
     ],
     "description": "Froala Editor is a WYSIWYG HTML Editor written in Javascript that enables rich text editing capabilities for applications.",
-    "html": "<[^>]+class=\"[^\"]*(?:fr-view|fr-box)",
+    "dom": ".fr-view, .fr-box, .fr-popup, .froala-box",
     "icon": "Froala.svg",
     "implies": [
       "jQuery",
       "Font Awesome"
     ],
+    "js": {
+      "FroalaEditor.VERSION": "([\\d\\.]+)\\;version:\\1"
+    },
     "website": "http://froala.com/wysiwyg-editor"
   },
   "FrontPage": {


### PR DESCRIPTION
- `dom` rule replaces `html` rule that inadvertently expected discriminating class name to appear last in the class list
- Version detection for Froala 2+
- Additional discriminating class for popup editors (existing code doesn't recognize Froala on [these](https://froala.com/wysiwyg-editor/examples/edit-in-popup/) official [demos](https://froala.com/wysiwyg-editor/examples/init-on-button/))
- Additional discriminating class for Froala 1.x