### PR TITLE
Add Ordersify Product Alerts / shopify-apps #5830

### DIFF
--- a/src/drivers/webextension/images/icons/Ordersify.svg
+++ b/src/drivers/webextension/images/icons/Ordersify.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M32 0H0V32H32V0Z" fill="#3D4854"/>
+<path d="M16 23.2C19.9765 23.2 23.2 19.9765 23.2 16C23.2 12.0236 19.9765 8.8 16 8.8C12.0236 8.8 8.8 12.0236 8.8 16C8.8 19.9765 12.0236 23.2 16 23.2Z" stroke="white" stroke-width="5"/>
+</svg>

--- a/src/technologies/o.json
+++ b/src/technologies/o.json
@@ -1231,6 +1231,25 @@
     "saas": true,
     "website": "https://apps.shopify.com/orderlogic"
   },
+  "Ordersify Product Alerts": {
+    "cats": [
+      100
+    ],
+    "description": "Ordersify Product Alerts is a Shopify app which detects automatically product stock and send email alerts to contact immediately after your products are restocked.",
+    "icon": "Ordersify.svg",
+    "implies": "Shopify",
+    "js": {
+      "ORDERSIFY_BIS.stockRemainingSetting": ""
+    },
+    "pricing": [
+      "freemium",
+      "low",
+      "recurring"
+    ],
+    "saas": true,
+    "scriptSrc": "cdn\\.ordersify\\.com/sdk/productalerts-shopify\\.js",
+    "website": "https://ordersify.com/products/product-alerts"
+  },
   "OrderYOYO": {
     "cats": [
       6


### PR DESCRIPTION
### request #5830
### website
https://ordersify.com/products/product-alerts
https://apps.shopify.com/ordersify-product-alerts
### examples
https://scrawlrbox.uk/
https://www.vpa.com.au/
https://www.dollyanddotty.co.uk/
https://adnams.co.uk/
https://www.teapigs.co.uk/