### PR TITLE
Update Microsoft ASP.NET / Web frameworks

### DIFF
--- a/src/technologies/m.json
+++ b/src/technologies/m.json
@@ -1199,7 +1199,6 @@
     },
     "html": "<input[^>]+name=\"__VIEWSTATE",
     "icon": "Microsoft ASP.NET.svg",
-    "implies": "IIS\\;confidence:50",
     "url": "\\.aspx?(?:$|\\?)",
     "website": "https://www.asp.net"
   },


### PR DESCRIPTION
Since ASP.NET and its related technologies like Blazor are no longer Windows and Internet Information Services exclusive, it would be incorrect to reference Windows Server and IIS at all.