### PR TITLE
Add lite-youtube-embed detection

### DIFF
--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -1563,5 +1563,14 @@
     },
     "oss": true,
     "website": "https://lit.dev"
+  },
+  "lite-youtube-embed": {
+    "cats": [
+      59
+    ],
+    "description": "A faster youtube embed.",
+    "html": "<(?:lite-youtube)",
+    "icon": "YouTube.png",
+    "website": "https://github.com/paulirish/lite-youtube-embed"
   }
 }

--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -1568,9 +1568,10 @@
     "cats": [
       59
     ],
-    "description": "A faster youtube embed.",
-    "html": "<(?:lite-youtube)",
-    "icon": "YouTube.png",
-    "website": "https://github.com/paulirish/lite-youtube-embed"
+    "description": "The lite-youtube-embed technique renders the YouTube video inside the IFRAME tag only when the play button in clicked thus improving the core web vitals score of your website.",
+    "dom": "lite-youtube",
+    "website": "https://github.com/paulirish/lite-youtube-embed",
+    "oss": true, 
+    "implies": "YouTube"
   }
 }


### PR DESCRIPTION
GitHub page: https://github.com/paulirish/lite-youtube-embed (4.2k stars)
Demo: https://paulirish.github.io/lite-youtube-embed/

**node src/drivers/npm/cli.js https://paulirish.github.io/lite-youtube-embed/**
```
{
  "urls": {
    "https://paulirish.github.io/lite-youtube-embed/": { "status": 200 }
  },
  "technologies": [
    // ...
    {
      "slug": "lite-youtube-embed",
      "name": "lite-youtube-embed",
      "confidence": 100,
      "version": null,
      "icon": "YouTube.png",
      "website": "https://github.com/paulirish/lite-youtube-embed",
      "cpe": null,
      "categories": [
        {
          "id": 59,
          "slug": "javascript-libraries",
          "name": "JavaScript libraries"
        }
      ]
    }
    // ...
  ]
}

```

Sample pages (selected at random): 
- https://www.techbang.com/
- https://www.musicnotes.com/
- https://www.cgtrader.com/
- https://connectify.me/
- https://www.driversupport.com/
- https://www.canalturf.com/
- https://saucelabs.com/

Note: The technology does not have its own icon so I reused the YouTube icon.