### PR TITLE
Fix the problem that missing slash cannot be copied during docker build

### DIFF
--- a/src/drivers/npm/Dockerfile
+++ b/src/drivers/npm/Dockerfile
@@ -24,7 +24,7 @@ COPY \
   driver.js \
   package.json \
   wappalyzer.js \
-  yarn.lock .
+  yarn.lock ./
 
 RUN yarn install
 


### PR DESCRIPTION
Adding multiple files to a directory in docker requires a slash, if there is no slash then it cannot be copied to docker properly, this fix can build docker images properly