### PR TITLE
Improved reliability of webpack check

### DIFF
--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -1758,7 +1758,8 @@
     "description": "Webpack is an open-source JavaScript module bundler.",
     "icon": "webpack.svg",
     "js": {
-      "webpackJsonp": ""
+      "webpackJsonp": "",
+      "webpackChunk": ""
     },
     "website": "https://webpack.js.org/"
   },


### PR DESCRIPTION
There are a number of pages which use Webpack but are currently not identified correctly. The current check is on the `webpackJsonp` global variable, but in some cases Webpack uses `webpackChunk` instead, depending on the Webpack configuration.

GitHub page: https://github.com/webpack/webpack

**Example**
```
node src/drivers/npm/cli.js https://feedly.com/
```

**Before the fix:**
```
{
  "urls": {
    "https://feedly.com/": { "status": 200 }
  },
  "technologies": [
    // ...
    // no webpack
    // ...
  ]
}
```

**After the fix:**
```
{
  "urls": {
    "https://feedly.com/": { "status": 200 }
  },
  "technologies": [
    // ...
    {
      "slug": "webpack",
      "name": "webpack",
      "confidence": 100,
      "version": null,
      "icon": "webpack.svg",
      "website": "https://webpack.js.org/",
      "cpe": null,
      "categories": [
        { "id": 19, "slug": "miscellaneous", "name": "Miscellaneous" }
      ]
    }
    // ...
  ]
}
```

Sample pages (selected at random):
- https://feedly.com/
- https://overstepgame.com/
- https://www.peoplefinders.com/
- https://www.websupport.sk/
- https://www.cool3c.com/
