### PR TITLE
Add Fastly detection headers

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -349,9 +349,11 @@
       "Fastly-Debug-Digest": "",
       "Vary": "Fastly-SSL",
       "X-Fastly-Request-ID": "",
+      "x-fastly-request-id": "",
       "x-fastly-origin": "",
       "x-served-by": "^cache-",
-      "x-via-fastly:": ""
+      "x-via-fastly:": "",
+      "server": "Fastly"
     },
     "icon": "Fastly.svg",
     "pricing": [


### PR DESCRIPTION
examples:
- https://github.com/ (https://github.githubassets.com/assets/dark-d4a90c367f0c.css)
<img width="447" alt="image" src="https://user-images.githubusercontent.com/18487241/176116239-b47a091c-79b4-43a8-9b06-900083fceb51.png">


- https://stripe.com/ (https://b.stripecdn.com/mkt-statics-srv/assets/App-58f708b1.js)
<img width="502" alt="image" src="https://user-images.githubusercontent.com/18487241/176116279-405e2407-5d59-431f-a281-f9d6acd58b32.png">
