### PR TITLE
Fix lazysize unveilhooks regex

### DIFF
--- a/src/technologies/l.json
+++ b/src/technologies/l.json
@@ -229,7 +229,7 @@
     "description": "LazySizes unveilhooks plugin extends lazySizes to lazyload scripts/widgets, background images, styles and video/audio elements.",
     "icon": "default.svg",
     "oss": true,
-    "scriptSrc": "ls.\\unveilhooks(?:\\.min)?\\.js",
+    "scriptSrc": "ls\\.unveilhooks(?:\\.min)?\\.js",
     "website": "https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/unveilhooks"
   },
   "Leadinfo": {


### PR DESCRIPTION
According to the ticket https://github.com/wappalyzer/wappalyzer/issues/5972, we are looking for script 'ls.unveilhooks.js' or 'ls.unveilhooks.min.js'.

It is just a small fix in the regex in order to escape the point "."