### PR TITLE
Update Framer detection

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -1317,8 +1317,10 @@
     "icon": "Framer Sites.svg",
     "implies": "React",
     "js": {
+      "Framer": "",
       "Framer.Animatable": "",
-      "Framer.version": "([\\d\\.]+)\\;version:\\1\\;confidence:0"
+      "Framer.version": "([\\d\\.]+)\\;version:\\1\\;confidence:0",
+      "__framer_importFromPackage": ""
     },
     "oss": false,
     "pricing": [


### PR DESCRIPTION
Framer Sites detection does not work properly.

examples
- https://basement.dev/
- https://www.capchase.design/
- https://www.exomon.xyz/