### PR TITLE
Fix URL property from request object

### DIFF
--- a/src/drivers/webextension/js/driver.js
+++ b/src/drivers/webextension/js/driver.js
@@ -439,9 +439,7 @@ const Driver = {
 
     const scripts = (await response.text()).slice(0, 500000)
 
-    Driver.onDetect(request.url, analyze({ scripts })).catch(
-      Driver.error
-    )
+    Driver.onDetect(request.url, analyze({ scripts })).catch(Driver.error)
   },
 
   /**

--- a/src/drivers/webextension/js/driver.js
+++ b/src/drivers/webextension/js/driver.js
@@ -419,7 +419,7 @@ const Driver = {
       return
     }
 
-    const { hostname } = new URL(request.documentUrl)
+    const { hostname } = new URL(request.url)
 
     if (!Driver.cache.hostnames[hostname]) {
       Driver.cache.hostnames[hostname] = {}
@@ -439,7 +439,7 @@ const Driver = {
 
     const scripts = (await response.text()).slice(0, 500000)
 
-    Driver.onDetect(request.documentUrl, analyze({ scripts })).catch(
+    Driver.onDetect(request.url, analyze({ scripts })).catch(
       Driver.error
     )
   },


### PR DESCRIPTION
I've been running into a few issues related to detections not being picked up when the detection regex seems to be correct. After a bit debugging, I discovered that the URL being passed to the script detection was undefined (using an old convention, I'm assuming), which was causing the script detection to error out.

It looks like in Chrome, the `chrome.webrequest.oncompleted` sends back the request object which uses the url property instead of the current `documentURL` property (see link below).

https://developer.chrome.com/docs/extensions/reference/webRequest/#property-onCompleted-callback-details-url

The `request.url` prop is already being used, so I'm guessing this was just overlooked.