### PR TITLE
Fix Acquia Customer Data Platform

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -620,9 +620,6 @@
       "[data-function*='Agilone']"
     ],
     "icon": "acquia-cdp.png",
-    "implies": [
-      "Acquia Cloud Platform"
-    ],
     "js": {
       "$A1Config": "",
       "$A1": "",

--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -613,7 +613,7 @@
   },
   "Acquia Customer Data Platform": {
     "cats": [
-      10
+      97
     ],
     "description": "Acquia Customer Data Platform (formerly AgilOne) is a customer data platform for Drupal.",
     "dom": [
@@ -624,6 +624,8 @@
       "Acquia Cloud Platform"
     ],
     "js": {
+      "$A1Config": "",
+      "$A1": "",
       "agiloneObject": ""
     },
     "saas": true,


### PR DESCRIPTION
Adding more JS object detection, and updating category for CDP (was previously analytics). I also removed the Acquia Cloud implication, as customers who were using AgilOne before they were acquired, don't actually use the Acquia platform. There are other detections to independently identify that.