### PR TITLE
Fix exiting with error code when help is called

### DIFF
--- a/src/drivers/npm/cli.js
+++ b/src/drivers/npm/cli.js
@@ -91,8 +91,7 @@ Options:
   -N, --no-redirect        Disable cross-domain redirects
   -e, --extended           Output additional information
 `)
-
-  process.exit(1)
+  process.exit(options.help ? 0 : 1)
 }
 
 const headers = {}


### PR DESCRIPTION
`--help` is an accepted option and should not return `1` (error) as exit code but success `0`. However, the CLI will still return `0` if help text is forced due to missing URL.