### PR TITLE
Update shelf detection logic with latest header

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -1733,7 +1733,8 @@
     ],
     "description": "Shelf is a server framework for Dart.",
     "headers": {
-      "Server": "dart:io with Shelf"
+      "Server": "dart:io with Shelf",
+      "x-powered-by": "Dart with package:shelf"
     },
     "oss": true,
     "icon": "Dart.svg",


### PR DESCRIPTION
As of v1.3.2 the header is "X-Powered-By": "Dart with package:shelf"

Leaving previous value to allow detection of older versions
