### PR TITLE
fastly: drop overly general response header

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -353,7 +353,6 @@
       "server": "Fastly",
       "x-fastly-origin": "",
       "x-fastly-request-id": "",
-      "x-served-by": "^cache-",
       "x-via-fastly:": ""
     },
     "icon": "Fastly.svg",


### PR DESCRIPTION
An x-served-by header starting with `cache-` could be anyone...
