### PR TITLE
Google App Engine: fix website, lower confidence in header

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -1400,9 +1400,6 @@
     "cats": [
       22
     ],
-    "headers": {
-      "Server": "Google Frontend\\;confidence:30"
-    },
     "icon": "Google App Engine.svg",
     "website": "https://cloud.google.com/appengine"
   },

--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -1401,10 +1401,10 @@
       22
     ],
     "headers": {
-      "Server": "Google Frontend"
+      "Server": "Google Frontend\\;confidence:30"
     },
     "icon": "Google App Engine.svg",
-    "website": "http://code.google.com/appengine"
+    "website": "https://cloud.google.com/appengine"
   },
   "Google Call Conversion Tracking": {
     "cats": [


### PR DESCRIPTION
"Server": "Google Frontend" could be a number of other things, including
Google Cloud Run
