### PR TITLE
Add HTTP/3 detection

### DIFF
--- a/src/technologies/h.json
+++ b/src/technologies/h.json
@@ -71,7 +71,8 @@
     "description": "HTTP/2 (originally named HTTP/2.0) is a major revision of the HTTP network protocol used by the World Wide Web.",
     "excludes": "SPDY",
     "headers": {
-      "X-Firefox-Spdy": "h2"
+      "X-Firefox-Spdy": "h2",
+      "Alt-Svc": "h2"
     },
     "icon": "http2.png",
     "website": "https://http2.github.io"
@@ -1439,5 +1440,16 @@
       "onetime"
     ],
     "website": "https://hyva.io/"
+  },
+  "HTTP/3": {
+    "cats": [
+      19
+    ],
+    "description": "HTTP/3 is the third major version of the Hypertext Transfer Protocol used to exchange information on the World Wide Web.",
+    "excludes": "HTTP/2",
+    "headers": {
+      "Alt-Svc": "h3"
+    },
+    "website": "https://httpwg.org/"
   }
 }


### PR DESCRIPTION
The [Alt-Svc](https://developer.mozilla.org/docs/Web/HTTP/Headers/Alt-Svc) header is used to check if the web server supports HTTP/3, I've added this check for HTTP/2 as well.
Unfortunately I couldn't find a suitable icon and the [badges](https://github.com/httpwg/wg-materials/tree/gh-pages/badge/http3) are too big. 