### PR TITLE
Improve mailman CPE and implication

### DIFF
--- a/src/technologies/m.json
+++ b/src/technologies/m.json
@@ -442,11 +442,11 @@
     "cats": [
       75
     ],
+    "cpe": "cpe:2.3:a:gnu:mailman:*:*:*:*:*:*:*:*",
     "description": "Mailman is free software for managing electronic mail discussion and e-newsletter lists. Mailman is integrated with the web, making it easy for users to manage their accounts and for list owners to administer their lists. Mailman supports built-in archiving, automatic bounce processing, content filtering, digest delivery, spam filters, and more.",
     "icon": "Mailman.svg",
     "implies": [
-      "Python",
-      "Django"
+      "Python"
     ],
     "oss": true,
     "scriptSrc": [


### PR DESCRIPTION
Remove Django implication from mailman. Mailman is not necessarily used
with Django but always with Python. Also add missing CPE.