### PR TITLE
Simplify Edgio name

### DIFF
--- a/src/technologies/e.json
+++ b/src/technologies/e.json
@@ -326,7 +326,7 @@
     "url": "https?://(?:[^/]+\\.)?edgecastcdn\\.net/",
     "website": "http://www.edgecast.com"
   },
-  "Edgio App Platform": {
+  "Edgio": {
     "cats": [
       31,
       62
@@ -336,7 +336,7 @@
       "layer0_destination": "",
       "layer0_eid": ""
     },
-    "description": "Edgio App Platform is an integrated suite of Edge services, from Delivery to Compute.",
+    "description": "Edgio is an integrated suite of Edge services, from Delivery to Compute.",
     "headers": {
       "x-0-status": "",
       "x-0-t": "",


### PR DESCRIPTION
Product team requested that we simplify the name reported in Wappalyzer since "App Platform" is one distinct offering that Edgio provides, and isn't representative of the entire suite of tools.