### PR TITLE
Revert description for eSSENTIAL Accessibility classifying it as overlay

### DIFF
--- a/src/technologies/e.json
+++ b/src/technologies/e.json
@@ -1735,7 +1735,7 @@
     "cats": [
       68
     ],
-    "description": "eSSENTIAL Accessibility provides an accessibility overlay for websites.",
+    "description": "eSSENTIAL Accessibility is a digital accessibility-as-a-service platform.",
     "dom": " a[href*='.essentialaccessibility.com'] > img",
     "icon": "eSSENTIAL Accessibility.png",
     "pricing": [


### PR DESCRIPTION
This reverts part of #4520, where eSSENTIAL Accessibility’s description was changed so it is presented as an overlay. Whether a given site uses an overlay or not is very important, as there is [a lot of movement against overlays](https://overlayfactsheet.com/).

As far as I can tell [from their website](https://www.essentialaccessibility.com/), they don’t offer an overlay. They do have their logo featured on a lot of websites. Here is the (shortened) HTML from [piazza.com](https://piazza.com/). As far as I can tell, this is just a link with an image in it:

```html
<a href="https://www.essentialaccessibility.com/piazza" target="_blank">
  <img src="/images/accessibility/ea_app_icon_new.png" alt="Click this icon to learn more about our commitment to customers and employees with disabilities.">
</a>
```

They do offer a Windows / Mac / Android application ([see user manual](https://www.essentialaccessibility.com/user-manual/en/)), but as far as I can tell from the manual it’s just generic assistive technology that works with all applications on your computer, and doesn’t (seem to) modify websites when in use, and doesn’t treat sites with their logo any differently. They did seem to offer overlay-style functionality in the past, with the [2014 user manual](https://www.essentialaccessibility.com/new-user-guide/en/) describing something that seems more like a browser with overlay-style assistive tools built in.

---

Beyond the description, I also wonder if this should even be detected by Wappalyzer to start with? (added in #4237 for reference) The current detection really looks for the "link + image", there’s really no way to tell whether there is any "technology" from that company involved in building the page (there could be, or they could just have the link + image and that’s it). Personally I’m happy either way, but would be interested in understanding what makes the most sense for Wappalyzer.