### PR TITLE
Recategorise USWDS from Web frameworks to UI frameworks

### DIFF
--- a/src/technologies/u.json
+++ b/src/technologies/u.json
@@ -103,7 +103,7 @@
   },
   "USWDS": {
     "cats": [
-      18
+      66
     ],
     "description": "USWDS is a design system for the federal government.",
     "icon": "USWDS.svg",


### PR DESCRIPTION
Right now USWDS is displayed amongst [Web frameworks](https://www.wappalyzer.com/technologies/web-frameworks). It’s a design system, with no server-side code, and even client-side it doesn’t help structure applications – it’s just an assortment of components. So I think it would be better to see it amongst [UI frameworks](https://www.wappalyzer.com/technologies/ui-frameworks), like Bootstrap, or other design systems.