### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,13 @@ on:
   schedule:
     - cron: "30 0 * * *"
 
+permissions: {}
 jobs:
   close-issues:
+    permissions:
+      issues: write # to close stale issues (actions/stale)
+      pull-requests: write # to close stale PRs (actions/stale)
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v3

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -2,6 +2,9 @@ name: "submit"
 on: 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build: 
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   validate:
     name: Validate


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.