### PR TITLE
Added info for Inertia.js

### DIFF
--- a/src/technologies/i.json
+++ b/src/technologies/i.json
@@ -486,11 +486,11 @@
     },
     "website": "http://indyproject.org"
   },
-  "Inertia": {
+  "Inertia.js": {
     "cats": [
       12
     ],
-    "description": "Inertia is a protocol for creating monolithic single-page applications.",
+    "description": "Inertia.js is a protocol for creating monolithic single-page applications.",
     "dom": {
       "div[data-page*='component']": {
         "attributes": {
@@ -501,6 +501,10 @@
     "headers": {
       "X-Inertia": ""
     },
+    "implies": [
+      "Laravel\\;confidence:99",
+      "Ruby on Rails\\;confidence:1"
+    ],
     "icon": "Inertia.svg",
     "oss": true,
     "saas": false,

--- a/src/technologies/i.json
+++ b/src/technologies/i.json
@@ -501,13 +501,8 @@
     "headers": {
       "X-Inertia": ""
     },
-    "implies": [
-      "Laravel\\;confidence:99",
-      "Ruby on Rails\\;confidence:1"
-    ],
     "icon": "Inertia.svg",
     "oss": true,
-    "saas": false,
     "website": "https://inertiajs.com"
   },
   "InfernoJS": {


### PR DESCRIPTION
- It's written Inertia.js, not Inertia like the logo
- Laravel or Ruby on Rails are implied by Inertia.js
- The confidence numbers come from the [Laravel](https://github.com/inertiajs/inertia-laravel/network/dependents) and [Rails](https://github.com/inertiajs/inertia-rails/network/dependents) repositories (16,438 vs 128 uses)
- It also implies React, Vue, or Svelte but I think those can be detected better other ways