### PR TITLE
Add Google Font API detection method

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -1520,10 +1520,18 @@
       17
     ],
     "description": "Google Font API is a web service that supports open-source font files that can be used on your web designs.",
-    "html": [
-      "<link[^>]* href=[^>]+fonts\\.(?:googleapis|google|gstatic)\\.com",
-      "<style data-href=\"https://fonts.googleapis.com/css*\""
-    ],
+    "dom": {
+      "link[href*='fonts.g']": {
+        "attributes": {
+          "href": "fonts\\.(?:googleapis|google|gstatic)\\.com"
+        }
+      },
+      "style[data-href*='fonts.g']": {
+        "attributes": {
+          "data-href": "fonts\\.(?:googleapis|google|gstatic)\\.com"
+        }
+      }      
+    },
     "icon": "Google Font API.png",
     "js": {
       "WebFonts": ""

--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -1520,7 +1520,10 @@
       17
     ],
     "description": "Google Font API is a web service that supports open-source font files that can be used on your web designs.",
-    "html": "<link[^>]* href=[^>]+fonts\\.(?:googleapis|google)\\.com",
+    "html": [
+      "<link[^>]* href=[^>]+fonts\\.(?:googleapis|google|gstatic)\\.com",
+      "<style data-href=\"https://fonts.googleapis.com/css*\""
+    ],
     "icon": "Google Font API.png",
     "js": {
       "WebFonts": ""


### PR DESCRIPTION
When using Google Fonts with the Next.js framework.
Next.js automatically optimizes the google font API, so wappalyzer cannot detect it.

(e.g. https://umami.is)


+ I'm not sure this line is correct.
`"<style data-href=\"https://fonts.googleapis.com/css*\""`