### PR TITLE
feat: add bunnycdn default subdomain

### DIFF
--- a/src/technologies/b.json
+++ b/src/technologies/b.json
@@ -2261,6 +2261,7 @@
     "headers": {
       "Server": "^BunnyCDN"
     },
+    "dom": "[src*='.b-cdn.net'],[data-src*='.b-cdn.net']",
     "icon": "Bunny.png",
     "website": "https://bunny.net"
   },


### PR DESCRIPTION
*.b-cdn.net is the default domain for zones at bunnycdn