### PR TITLE
Update HSTS / security

### DIFF
--- a/src/technologies/h.json
+++ b/src/technologies/h.json
@@ -113,6 +113,7 @@
     "headers": {
       "Strict-Transport-Security": ""
     },
+    "url": "^https://[\\w\\d\\.\\-]+(?:\\.dev)(?:/.+||/)$",
     "website": "https://www.rfc-editor.org/rfc/rfc6797#section-6.1"
   },
   "HTTP/2": {


### PR DESCRIPTION
### example
https://www.andrewdragon.dev/

###  WIKI: 
.dev is a top-level domain name operated by Google.[1] It was proposed in ICANN's new generic top-level domain (gTLD) program, and became available to the general public on March 1, 2019, with an early access period that began on February 19.[2] To increase the security of the domains, the entire gTLD has been included in the HSTS preload-list; as a result, popular web browsers will only connect to a .dev webpage using HTTPS.[2]