### PR TITLE
Update SiteCore detection.

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -3224,7 +3224,11 @@
     },
     "cpe": "cpe:2.3:a:sitecore:*:*:*:*:*:*:*:*:*",
     "description": "Sitecore provides web content management, and multichannel marketing automation software.",
-    "html": "<img[^>]+src=\"[^>]*/~/media/[^>]+\\.ashx",
+    "dom": [
+      "link[href*='/_sitecore/']",
+      "img[src^='/-/media/']",
+      "img[src*='/~/media/.+\\.ashx']"
+    ],
     "icon": "Sitecore.svg",
     "pricing": [
       "poa",


### PR DESCRIPTION
Moves to the `dom` method of selection.

Example sites

* https://www.environment.nsw.gov.au/
* https://www.vicroads.vic.gov.au/