### PR TITLE
Update Shopify / ecommerce

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -2339,9 +2339,10 @@
     },
     "icon": "Shopify.svg",
     "js": {
-      "Shopify": "\\;confidence:25",
+      "SHOPIFY_API_BASE_URL": "",
       "ShopifyAPI": "",
-      "ShopifyCustomer": ""
+      "ShopifyCustomer": "",
+      "Shopify": "\\;confidence:25"
     },
     "meta": {
       "shopify-checkout-api-token": "",


### PR DESCRIPTION
### Strange behavior
If js object **Shopify**  comes first in the js array then confidence remains at 25% despite 100% matches and confidence in other keywords. Well, this is an old kind of problem with the summation of confidence.

I moved it to the end and confidence for some reason I don’t understand became 100% and now Shopify will show in extensions what one user complained about on the example of this site, because the extension does not show below 50% confidence if I don’t confuse anything
### examples:
https://grovemade.com/product/black-pen-and-pen-stand/?initial=491
