### PR TITLE
Add detection for WordPress themes Twenty Twenty-Two and Twenty Twenty-Three

### DIFF
--- a/src/technologies/t.json
+++ b/src/technologies/t.json
@@ -2936,6 +2936,9 @@
     "dom": {
       "style#webfonts-inline-css": {
         "text": "/wp-content/themes/twentytwentythree/assets/fonts/"
+      },
+      "style#wp-webfonts-inline-css": {
+        "text": "/wp-content/themes/twentytwentythree/assets/fonts/"
       }
     },
     "icon": "WordPress.svg",
@@ -2953,6 +2956,9 @@
     "dom": {
       "link#twentytwentytwo-style-css": {},
       "style#webfonts-inline-css": {
+        "text": "/wp-content/themes/twentytwentytwo/assets/fonts/"
+      },
+      "style#wp-webfonts-inline-css": {
         "text": "/wp-content/themes/twentytwentytwo/assets/fonts/"
       }
     },

--- a/src/technologies/t.json
+++ b/src/technologies/t.json
@@ -2932,8 +2932,12 @@
     "cats": [
       80
     ],
-    "css": "\\/wp-content\\/themes\\/twentytwentythree\\/assets\\/fonts\\/",
     "description": "Twenty Twenty-Three is the default WordPress theme for 2023.",
+    "dom": {
+      "style#webfonts-inline-css": {
+        "text": "/wp-content/themes/twentytwentythree/assets/fonts/"
+      }
+    },
     "icon": "WordPress.svg",
     "pricing": [
       "freemium"
@@ -2945,9 +2949,15 @@
     "cats": [
       80
     ],
-    "css": "\\/wp-content\\/themes\\/twentytwentytwo\\/assets\\/fonts\\/",
     "description": "Twenty Twenty-Two is the default WordPress theme for 2022.",
-    "dom": "link#twentytwentytwo-style-css",
+    "dom": [
+      "link#twentytwentytwo-style-css",
+      {
+        "style#webfonts-inline-css": {
+          "text": "/wp-content/themes/twentytwentytwo/assets/fonts/"
+        }
+      }
+    ],
     "icon": "WordPress.svg",
     "pricing": [
       "freemium"

--- a/src/technologies/t.json
+++ b/src/technologies/t.json
@@ -2950,14 +2950,12 @@
       80
     ],
     "description": "Twenty Twenty-Two is the default WordPress theme for 2022.",
-    "dom": [
-      "link#twentytwentytwo-style-css",
-      {
-        "style#webfonts-inline-css": {
-          "text": "/wp-content/themes/twentytwentytwo/assets/fonts/"
-        }
+    "dom": {
+      "link#twentytwentytwo-style-css": {},
+      "style#webfonts-inline-css": {
+        "text": "/wp-content/themes/twentytwentytwo/assets/fonts/"
       }
-    ],
+    },
     "icon": "WordPress.svg",
     "pricing": [
       "freemium"

--- a/src/technologies/t.json
+++ b/src/technologies/t.json
@@ -2928,6 +2928,33 @@
     "scriptSrc": "/wp-content/themes/twentytwentyone/",
     "website": "https://wordpress.org/themes/twentytwentyone"
   },
+  "Twenty Twenty-Three": {
+    "cats": [
+      80
+    ],
+    "css": "\\/wp-content\\/themes\\/twentytwentythree\\/assets\\/fonts\\/",
+    "description": "Twenty Twenty-Three is the default WordPress theme for 2023.",
+    "icon": "WordPress.svg",
+    "pricing": [
+      "freemium"
+    ],
+    "requires": "WordPress",
+    "website": "https://wordpress.org/themes/twentytwentythree"
+  },
+  "Twenty Twenty-Two": {
+    "cats": [
+      80
+    ],
+    "css": "\\/wp-content\\/themes\\/twentytwentytwo\\/assets\\/fonts\\/",
+    "description": "Twenty Twenty-Two is the default WordPress theme for 2022.",
+    "dom": "link#twentytwentytwo-style-css",
+    "icon": "WordPress.svg",
+    "pricing": [
+      "freemium"
+    ],
+    "requires": "WordPress",
+    "website": "https://wordpress.org/themes/twentytwentytwo"
+  },
   "TwicPics": {
     "cats": [
       31,


### PR DESCRIPTION
This PR intends to add detection for the WordPress default themes Twenty Twenty-Two and Twenty Twenty-Three, which are currently missing from the list of WordPress default themes that Wappalyzer detects.

Before reviewing the code, please read the following concerns:
* Those two themes (as well as likely any WordPress default themes in the future) follow a new theme development paradigm which, while it has several benefits, makes it quite a bit harder to identify such a theme being used.
* Twenty Twenty-Two still comes with a stylesheet that identifies the theme, so this one is still relatively straightforward, however it already lacks all other criteria that Wappalyzer relies on to detect previous WordPress default themes. Twenty Twenty-Three however does not load any stylesheet that identifies the theme, so here the PR is currently not working.
* The only thing that both themes _do_ load which we may be able to detect is some web font files that are within the theme's directory (`wp-content/themes/twentytwentytwo/assets/fonts` and `wp-content/themes/twentytwentythree/assets/fonts` respectively). However I'm unsure whether/how we can detect that via Wappalyzer.
    * I haven't found any technology property related to web fonts. Potentially we can somehow use the `css` property to detect the web font references? That's what I tried, but I don't know how that property is supposed to work, so any advice would be much appreciated.
    * FYI in both of the themes the web font reference is within inline CSS (i.e. not in an external CSS file). Maybe that helps.

For example URLs using the two themes, see:
* https://wp-themes.com/twentytwentytwo/
* https://wp-themes.com/twentytwentythree/