### PR TITLE
Add WP Live Visitor Counter / wp-plugin, widget

### DIFF
--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -230,6 +230,17 @@
     "scriptSrc": "/wp-content/plugins/wp-rocket/",
     "website": "https://wp-rocket.me"
   },
+  "WP Live Visitor Counter": {
+    "cats": [
+      87,
+      5
+    ],
+    "description": "WP Live Visitor Counter is a WordPress plugin that displays the number of online visitors on a website in real-time.",
+    "dom": "link[href*='/wp-content/plugins/wp-visitors-widget/']",
+    "icon": "default.svg",
+    "requires": "WordPress",
+    "website": "https://wordpress.org/plugins/wp-visitors-widget/"
+  },
   "WP-Optimize": {
     "cats": [
       87,


### PR DESCRIPTION
### website:
https://wordpress.org/plugins/wp-visitors-widget/
### examples:
https://zakatinst.net/ar/
https://www.hileytech.com/
https://radicalsoapbox.com/
https://maketbandung.com/