### PR TITLE
Update Page builders / priority

### DIFF
--- a/src/categories.json
+++ b/src/categories.json
@@ -347,7 +347,7 @@
       9
     ],
     "name": "Page builders",
-    "priority": 2
+    "priority": 1
   },
   "52": {
     "groups": [


### PR DESCRIPTION
Can we raise this category to the top?
Many people write that technology in this category is not defined. Apparently they expect to see him at the beginning
example:
https://msplaunchpaddemo.com/