### PR TITLE
Adding Stackbit

### DIFF
--- a/src/drivers/webextension/images/icons/stackbit.svg
+++ b/src/drivers/webextension/images/icons/stackbit.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1.4745,0,0,1.4745,0.00191685,4.08118e-12)">
+        <path d="M4.006,0C3.479,-0 2.958,0.104 2.472,0.306C1.985,0.507 1.543,0.803 1.171,1.176C0.799,1.548 0.504,1.991 0.303,2.477C0.102,2.964 -0.001,3.486 0,4.012L0,10.021C-0,10.515 0.137,11 0.396,11.421C0.656,11.843 1.027,12.184 1.468,12.406L6.683,15.024L6.683,6.677L15.024,6.677L21.688,0L4.006,0Z" style="fill:rgb(255,54,78);fill-rule:nonzero;"/>
+    </g>
+    <g transform="matrix(1.4745,0,0,1.4745,0.00191685,4.08118e-12)">
+        <path d="M17.695,21.702C18.757,21.702 19.776,21.28 20.527,20.529C21.278,19.777 21.7,18.759 21.7,17.696L21.7,11.687C21.699,11.191 21.561,10.706 21.301,10.285C21.041,9.864 20.668,9.524 20.226,9.302L15.024,6.677L15.024,15.024L6.683,15.024L0.013,21.702L17.695,21.702Z" style="fill:rgb(255,54,78);fill-rule:nonzero;"/>
+    </g>
+</svg>

--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -5497,6 +5497,30 @@
     "icon": "StackPath.svg",
     "website": "https://www.stackpath.com"
   },
+  "Stackbit": {
+    "cats": [
+      51
+    ],
+    "description": "Stackbit is a visual experience platform for building decoupled websites.",
+    "dom": {
+      "script#__NEXT_DATA__": {
+        "text": "stackbit"
+      }
+    },
+    "icon": "stackbit.svg",
+    "js": {
+      "__NEXT_DATA__.props.pageProps.withStackbit": ""
+    },
+    "scriptSrc": [
+      "\\.stackbit\\.com"
+    ],
+    "pricing": [
+      "mid",
+      "recurring"
+    ],
+    "saas": true,
+    "website": "https://www.stackbit.com"
+  },
   "StackerHQ": {
     "cats": [
       51


### PR DESCRIPTION
Stackbit is a page builder tool to use in conjunction with headless CMSes and decoupled build services. Some examples of customers:

- https://www.takeda.com/
- https://www.abodu.com/
- https://vise.com/
- https://materialize.com/
- https://www.wellsterhealth.com/
- https://www.empathy.com/

This is a newer service that has been implemented with larger customers, but published case studies and companies are limited. Adding this detection would help identify other websites that are adopting this platform.