### PR TITLE
Fix webextension `js` detection

### DIFF
--- a/src/drivers/webextension/js/js.js
+++ b/src/drivers/webextension/js/js.js
@@ -19,8 +19,7 @@
                   (value, method) =>
                     value &&
                     value instanceof Object &&
-                    Object.prototype.hasOwnProperty.call(value, method) &&
-                    !(Object.getOwnPropertyDescriptor(value, method) || {}).get
+                    Object.prototype.hasOwnProperty.call(value, method)
                       ? value[method]
                       : '__UNDEFINED__',
                   window


### PR DESCRIPTION
The change is about this condition:

```js
!(Object.getOwnPropertyDescriptor(value, method) || {}).get
```
It was first introduced in [this commit](https://github.com/wappalyzer/wappalyzer/commit/600e4f17495aa566330f0e1c2f49ca1c84240c0e#diff-6fc9ddd7a9f9994c94ccfb6a2b7c66cfa7303c7fef747f8e1d1f8a9a3d0e296b). But the problem is, it fails on some things. One such situation is when an object is a module. **In such module using getters is the intended behavior, and this condition ruins it.**

![image](https://user-images.githubusercontent.com/23292709/222282082-7a49b918-e4ef-4869-bf29-3bff87abae8f.png)
https://allegrolokalnie.pl/
`Phoenix.Channel`

**I think removing this `getOwnPropertyDescriptor` rule would drastically improve detectability on some technologies, as many technologies may have a situation similar to one with module.**

The existing check `Object.prototype.hasOwnProperty.call(value, method)` works well enough.

Would love to hear your thoughts on this @AliasIO

