### PR TITLE
Fix Phoenix and Phoenix Framework detection

### DIFF
--- a/src/technologies/p.json
+++ b/src/technologies/p.json
@@ -1189,9 +1189,6 @@
       "Webpack",
       "Node.js"
     ],
-    "js": {
-      "Phoenix": ""
-    },
     "meta": {
       "generator": "^phoenix"
     },
@@ -1204,6 +1201,9 @@
     "description": "Phoenix Framework is an open-source web application framework built using the Elixir programming language.",
     "icon": "Phoenix Framework.svg",
     "implies": "Elixir",
+    "js": {
+      "Phoenix.Channel": ""
+    },
     "oss": true,
     "website": "https://www.phoenixframework.org"
   },


### PR DESCRIPTION
If you check the `Phoenix` instance, or just watch the WebSocket connection - you will find that it's actually [Phoenix Framework](https://www.phoenixframework.org/), not [Sazito-Phoenix](https://github.com/Sazito/phoenix/). **I couldn't find any reference to global "Phoenix" in Sazito-Phoenix. (Sazito-Phoenix does not have it)**

<details>
  <summary>Websocket connection from "Network" tab by "Phoenix Framework"</summary>
  
![Websocket connection from Phoenix Framework](https://user-images.githubusercontent.com/23292709/222149675-7059a808-8554-4580-a717-712e938f77b2.png)
</details>

Here are the methods that "Phoenix" instance from "Phoenix Framework" has: https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix/index.js#L201

All of them are present on the pages that were identified with Phoenix on [Wappalyzer website](https://www.wappalyzer.com/technologies/web-frameworks/phoenix/):
- `window.Phoenix.Channel`
- `window.Phoenix.LongPoll`
- `window.Phoenix.Presence`
- `window.Phoenix.Serializer`
- `window.Phoenix.Socket`

**Sazito-Phoenix and Phoenix Framework are two separate things and should be treated so. Thank you.**

Please see related PR [#7480](https://github.com/wappalyzer/wappalyzer/pull/7480) that updates the detection algorithm in the webextension, which fixes this and many others technology detections for browser extension.