### PR TITLE
Add Waveme / wp-theme, Waveform / widget

### DIFF
--- a/src/drivers/webextension/images/icons/Waveme.svg
+++ b/src/drivers/webextension/images/icons/Waveme.svg
@@ -1,0 +1,8 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.8 12.8V19.2" stroke="#FF5500" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.60001 9.60001V22.4" stroke="#FF5500" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.4 3.20001V28.8" stroke="#FF5500" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.2 11.2V20.8" stroke="#FF5500" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M24 8V24" stroke="#FF5500" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M28.8 14.4V17.6" stroke="#FF5500" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -536,6 +536,35 @@
     "implies": "Haskell",
     "website": "http://www.stackage.org/package/warp"
   },
+  "Waveme": {
+    "cats": [
+      80
+    ],
+    "description": "Waveme is a WordPress theme that is suitable for individuals or businesses involved in the music industry, such as music producers, record labels, artist managers, or independent artists.",
+    "dom": "link[href*='/wp-content/themes/waveme/']",
+    "icon": "Waveme.svg",
+    "implies": [
+      "Gutenberg",
+      "Waveform"
+    ],
+    "pricing": [
+      "onetime"
+    ],
+    "requires": "WordPress",
+    "website": "http://music.flatfull.com/waveme/about/"
+  },
+  "Waveform": {
+    "cats": [
+      5
+    ],
+    "description": "Waveform is a media player that supports various media formats, including audio, video, Youtube, and Vimeo, and includes a waveform visualisation feature, utilising Web Audio API and HTML5 Canvas technologies.",
+    "icon": "Waveme.svg",
+    "js": {
+      "Waveform": ""
+    },
+    "requires": "WordPress",
+    "website": "http://music.flatfull.com/waveme/about/"
+  },
   "Wazimo": {
     "cats": [
       36


### PR DESCRIPTION
### website:
http://music.flatfull.com/waveme/about/
### examples:
https://www.unlocktheotherside.com/
https://realdeejays.com/
https://musicout.com/
https://anyinstrumental.com/
https://djokawa.com/