### PR TITLE
Update Nginx CPE record

### DIFF
--- a/src/technologies/n.json
+++ b/src/technologies/n.json
@@ -794,7 +794,7 @@
       22,
       64
     ],
-    "cpe": "cpe:2.3:a:nginx:nginx:*:*:*:*:*:*:*:*",
+    "cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
     "description": "Nginx is a web server that can also be used as a reverse proxy, load balancer, mail proxy and HTTP cache.",
     "headers": {
       "Server": "nginx(?:/([\\d.]+))?\\;version:\\1",


### PR DESCRIPTION
Hello,

I have updated the CPE record for the Nginx web server. The previous CPE record in the NIST National Vulnerability Database referenced the previous version as `cpe:2.3:a:nginx:nginx:*:*:*:*:*:*:*:*`. However, Nginx is now supported by F5, so the CPE record has been updated to `cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*`.

These changes ensure the accurate identification of Nginx versions developed or supported by F5 and help improve the accuracy of vulnerability reports.

Please review the changes and let me know if any additional modifications are required.

Thank you.