### PR TITLE
Fixes varnich_cache -> varnish_cache typo in v.json technology file

### DIFF
--- a/src/technologies/v.json
+++ b/src/technologies/v.json
@@ -239,7 +239,7 @@
     "cats": [
       23
     ],
-    "cpe": "cpe:2.3:a:varnish-software:varnich_cache:*:*:*:*:*:*:*:*",
+    "cpe": "cpe:2.3:a:varnish-software:varnish_cache:*:*:*:*:*:*:*:*",
     "description": "Varnish is a reverse caching proxy.",
     "headers": {
       "Via": "varnish(?: \\(Varnish/([\\d.]+)\\))?\\;version:\\1",


### PR DESCRIPTION
Hi!

I spotted this typo for the varnish_cache CPE when trying to automatically look up CPEs found by Wappalyzer.

Thanks!