### PR TITLE
Update CrownPeak properties

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -3976,14 +3976,16 @@
   },
   "CrownPeak": {
     "cats": [
+      1,
       19
     ],
-    "description": "CrownPeak is a cloud-based Digital Experience Management (DEM) platform that is designed to in the management of digital experiences across multiple touch-points, especially for marketing and a freer IT architecture.",
+    "description": "CrownPeak is a cloud-based Digital Experience Platform (DXP).",
     "icon": "CrownPeak.png",
     "js": {
       "CrownPeakAutocomplete": "",
       "CrownPeakSearch": ""
     },
+    "scripts": "crownpeak\\.net",
     "pricing": [
       "poa"
     ],


### PR DESCRIPTION
CrownPeak is largely DXP centered around their web content platform product. This update will add the CMS category, which is already marked by the current detections, and simplify the description to keep standard with the current Wappalyzer technology descriptions.