### PR TITLE
Update Google Publisher Tag Domains

### DIFF
--- a/src/technologies/g.json
+++ b/src/technologies/g.json
@@ -1829,7 +1829,8 @@
     "icon": "Google Developers.svg",
     "scriptSrc": [
       "googletagservices\\.com/tag/js/gpt\\.js",
-      "securepubads\\.g\\.doubleclick\\.net/gpt"
+      "securepubads\\.g\\.doubleclick.net/tag/js/gpt\\.js",
+      "pagead2\\.googlesyndication\\.com/tag/js/gpt\\.js"
     ],
     "website": "https://developers.google.com/publisher-tag/guides/get-started"
   },


### PR DESCRIPTION
Many Origins are not classified as using "Google Publisher Tag" due to a buggy Google Publisher Tag Classification.

Default one: https://securepubads.g.doubleclick.net/tag/js/gpt.js

Limited Ads one: https://pagead2.googlesyndication.com/tag/js/gpt.js

Old: https://googletagservices.com/tag/js/gpt.js
