### PR TITLE
Add Mapbox.js / maps

### DIFF
--- a/src/technologies/m.json
+++ b/src/technologies/m.json
@@ -730,6 +730,19 @@
     "scriptSrc": "maplibre-gl@([\\d\\.]+)/dist/maplibre-gl\\.js\\;version:\\1",
     "website": "https://github.com/maplibre/maplibre-gl-js"
   },
+  "Mapbox.js": {
+    "cats": [
+      35
+    ],
+    "description": "Mapbox.js is a JavaScript library provided by Mapbox for working with interactive maps and geospatial data.",
+    "icon": "Mapbox.svg",
+    "implies": "Leaflet",
+    "dom": "link[href*='api.mapbox.com/']",
+    "oss": true,
+    "scripts": "api\\.mapbox\\.com/mapbox\\.js/v([\\d\\.]+)/\\;version:\\1",
+    "scriptSrc": "api\\.mapbox\\.com/mapbox\\.js/v([\\d\\.]+)/\\;version:\\1",
+    "website": "https://github.com/mapbox/mapbox.js"
+  },
   "Mapbox GL JS": {
     "cats": [
       35


### PR DESCRIPTION
### website:
https://docs.mapbox.com/help/glossary/mapbox-js/
https://github.com/mapbox/mapbox.js
### examples:
https://www.nuroa.com.ve/venta/casa-avenida-turmero?with_coords=1

https://www.colorline.no/
https://utcakereso.hu/
https://www.bca.fr/
https://www.ifsc.edu.br/
https://grains.org/
