### PR TITLE
Improve AdOpt detection

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -922,6 +922,7 @@
     ],
     "description": "AdOpt is a consent tool that prioritises privacy and usability towards the LGPD.",
     "icon": "AdOpt.svg",
+    "implies": "Svelte",
     "js": {
       "adoptApp.domain": "",
       "adopt_website_code": ""
@@ -932,6 +933,7 @@
       "recurring"
     ],
     "saas": true,
+    "scriptSrc": "https://tag.goadopt.io/injector.js",
     "website": "https://goadopt.io"
   },
   "AdRecover": {

--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -933,7 +933,7 @@
       "recurring"
     ],
     "saas": true,
-    "scriptSrc": "https://tag.goadopt.io/injector.js",
+    "scriptSrc": "tag\\.goadopt\\.io/",
     "website": "https://goadopt.io"
   },
   "AdRecover": {


### PR DESCRIPTION
Fixes #7677

AdOpt is not being detection on sites like https://allcomtelecom.com/

This updates the detection to look for scripts starting with `https://tag.goadopt.io/injector.js"`

It also adds `"implies": "Svelte",` as discussed in #7677