### PR TITLE
Add WordPress Multisite

### DIFF
--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -1946,6 +1946,32 @@
     "scriptSrc": "/wp-content/themes/default/",
     "website": "https://wordpress.org/themes/default"
   },
+  "WordPress Multisite": {
+    "cats": [
+      88
+    ],
+    "description": "A multisite network is a collection of sites that all share the same WordPress installation core files. ",
+    "dom": {
+      "figure[style*='wp-content/uploads']": {
+        "attributes": {
+          "style": "wp-content/uploads/sites/\\d+"
+        }
+      },
+      "img[src*='wp-content/uploads'], img[srcset*='wp-content/uploads'], source[srcset*='wp-content/uploads']": {
+        "attributes": {
+          "src": "wp-content/uploads/sites/\\d+",
+          "srcset": "wp-content/uploads/sites/\\d+"
+        }
+      },
+      "style": {
+        "text": "wp-content/uploads/sites/\\d+"
+      }
+    },
+    "icon": "WordPress.svg",
+    "requires": "WordPress",
+    "oss": true,
+    "website": "https://wordpress.org/documentation/article/create-a-network/"
+  },
   "WordPress Super Cache": {
     "cats": [
       23,


### PR DESCRIPTION
This detection adds support for finding WordPress Multisite (WPMS) installations. WPMS has been used an implemented by organizations all over the world, from small nonprofits, universities, and large enterprise organizations. This extends the WordPress detection to those sites that are using the WPMS configuration. Some example sites:

- https://careers.nba.com
- https://www.leaderpub.com
- https://www.coyoteridgegolfclub.com

![image](https://github.com/wappalyzer/wappalyzer/assets/1759794/b120e0c4-a81e-49ae-8d2d-6955b3dde823)
