### PR TITLE
fix(technologies): front-commerce dom elements

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -2385,7 +2385,7 @@
       "Node.js",
       "PWA"
     ],
-    "dom": "link[data-chunk*='front-commerce-src-web-theme-routes]",
+    "dom": "link[data-chunk*='front-commerce-src-web-theme-routes'], script[data-chunk*='front-commerce-src-web-theme-routes']",
     "website": "https://front-commerce.com"
   }
 }


### PR DESCRIPTION
## Why?
In the latest release of Front-Commerce (2.25) we worked on improving the loading performance, due to this change the link dom elements will no longer exist. 

This change keeps the `link` for previous versions and checks for an equivalent `script` for the latest version.

![image](https://github.com/wappalyzer/wappalyzer/assets/39598117/3ea2c14c-43d8-4233-9d41-47f3628056a5)


## Where to test
- [magento2.front-commerce.app](https://magento2.front-commerce.app/)
- [magento1.front-commerce.app](https://magento1.front-commerce.app/)
- [magento2-b2b.front-commerce.app](https://magento2-b2b.front-commerce.app/)

