### PR TITLE
Flarum implies Laravel usage

### DIFF
--- a/src/technologies/f.json
+++ b/src/technologies/f.json
@@ -867,7 +867,7 @@
     "html": "<div id=\"flarum-loading\"",
     "icon": "flarum.png",
     "implies": [
-      "PHP",
+      "Laravel",
       "MySQL"
     ],
     "js": {


### PR DESCRIPTION
Flarum uses Laravel and is built on top of it. If the programming language (PHP) is being detected, it would make sense for the framework to be detected as well.