### PR TITLE
Fix SolidStart falas detection

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -4651,7 +4651,7 @@
       "SolidJS"
     ],
     "js": {
-      "_$HY": ""
+      "_$HY.init": ""
     },
     "oss": true,
     "website": "https://start.solidjs.com"


### PR DESCRIPTION
Related: #7280 

From Astro 2.0, they have `window._$HY` for solid-js integration (even if it's not integrated)

so if the website uses Astro 2, `SolidStart` was falsely detected. 

(ref: https://github.com/withastro/astro/blob/main/packages/integrations/solid/src/client.ts#L8)


To fix this, I made js detection more strictly.


examples

Only Astro
- https://astro.build/
- https://robertonazareth.dev/

Only SolidStart
- https://start.solidjs.com/
- https://githubfk8exj-p0ad--3000--c53ab388.local-credentialless.webcontainer.io/

