### PR TITLE
Add WooCommerce Subscriptions / wp-plugin

### DIFF
--- a/src/technologies/w.json
+++ b/src/technologies/w.json
@@ -1877,6 +1877,21 @@
     "scriptSrc": "/wp-content/plugins/woocommerce-gateway-stripe/",
     "website": "https://woocommerce.com/products/stripe"
   },
+  "WooCommerce Subscriptions": {
+    "cats": [
+      87
+    ],
+    "description": "WooCommerce Subscriptions primarily allows you to create and sell subscription products from your WooCommerce shop.",
+    "dom": "link[href*='/wp-content/plugins/woocommerce-subscriptions/']",
+    "implies": "WooCommerce",
+    "icon": "WooCommerce.svg",
+    "pricing": [
+      "low",
+      "recurring"
+    ],
+    "requires": "WordPress",
+    "website": "https://woocommerce.com/products/woocommerce-subscriptions"
+  },
   "Woopra": {
     "cats": [
       10


### PR DESCRIPTION
### website
https://woocommerce.com/products/woocommerce-subscriptions/
### example:
https://www.prontonetworks.com/
http://actualicese.com/
https://hyperallergic.com/membership/
https://craftbundles.com/