### PR TITLE
Update Cargo / page-builder

### DIFF
--- a/src/technologies/c.json
+++ b/src/technologies/c.json
@@ -634,7 +634,7 @@
     "meta": {
       "cargo_title": ""
     },
-    "scriptSrc": "/cargo\\.",
+    "scriptSrc": "(?<!elo\\.io)/cargo\\.",
     "website": "https://cargo.site"
   },
   "Carrd": {


### PR DESCRIPTION
### example with BUG:
https://www.vlr.gg/232732/cloud9-vs-sentinels-champions-tour-2023-americas-last-chance-qualifier-ubsf
### normal example:
https://adhemas.com/

As an option, I updated the regular expression. Would it be better to remove it completely? too broad a search, leave it up to you