### PR TITLE
fix cloudfront incorrect implies

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -2677,7 +2677,6 @@
       "X-Amz-Cf-Id": ""
     },
     "icon": "Amazon Cloudfront.svg",
-    "implies": "Amazon Web Services",
     "saas": true,
     "website": "https://aws.amazon.com/cloudfront/"
   },


### PR DESCRIPTION
Just because a frontend loads, eg. a javascript file, hosted in Cloudfront does not imply the backend/website is using AWS as a PAAS.
