### PR TITLE
Fix cpes that are too long

### DIFF
--- a/src/technologies/a.json
+++ b/src/technologies/a.json
@@ -3110,7 +3110,7 @@
     "cats": [
       12
     ],
-    "cpe": "cpe:2.3:a:angularjs:angular:*:*:*:*:*:*:*:*:*",
+    "cpe": "cpe:2.3:a:angularjs:angular:*:*:*:*:*:*:*:*",
     "description": "Angular is a TypeScript-based open-source web application framework led by the Angular Team at Google.",
     "dom": {
       "[ng-version]": {

--- a/src/technologies/o.json
+++ b/src/technologies/o.json
@@ -433,7 +433,7 @@
     "cats": [
       1
     ],
-    "cpe": "cpe:2.3:a:omeka:omeka:*:*:*:*:*:*:*:*:*",
+    "cpe": "cpe:2.3:a:omeka:omeka:*:*:*:*:*:*:*:*",
     "description": "Omeka is a free Content Management System (CMS) used by archives, historical societies, libraries, museums, and individual researchers for publishing digital collections.",
     "icon": "Omeka.png",
     "dom": "link[rel*='stylesheet'][href*='css/myomeka.css'], link[rel*='stylesheet'][href*='/omeka/plugins/'], footer > p > a[href*='//omeka.org']",

--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -470,7 +470,7 @@
     "cookies": {
       "SAKAIID": ""
     },
-    "cpe": "cpe:2.3:a:sakailms:sakai:*:*:*:*:*:*:*:*:*",
+    "cpe": "cpe:2.3:a:sakailms:sakai:*:*:*:*:*:*:*:*",
     "description": "Sakai is a robust open-source learning management system created by higher ed for higher ed.",
     "icon": "Sakai.png",
     "js": {


### PR DESCRIPTION
CPE Version 2.3 should consist of 13 parts (all the others do in Wappalyzer (around 270). There are three CPE strings that consist of 14 parts. This PR corrects them.