### PR TITLE
Add Sitecore Experience Edge / caching,  Experience Platform / cms

### DIFF
--- a/src/technologies/s.json
+++ b/src/technologies/s.json
@@ -3674,6 +3674,40 @@
     "scriptSrc": "/sitecore-engage-v\\.([\\d\\.]+)\\.min\\.js\\;version:\\1",
     "website": "https://www.sitecore.com/products/engagement-cloud"
   },
+  "Sitecore Experience Edge": {
+    "cats": [
+      23
+    ],
+    "description": "Sitecore Experience Edge is a product that optimises content delivery by utilising edge computing and caching technologies to enhance website performance and user experience.",
+    "icon": "Sitecore.svg",
+    "requiresCategory": 12,
+    "implies": [
+      "GraphQL",
+      "Sitecore Experience Platform"
+    ],
+    "dom": "img[src*='edge.sitecorecloud.io']",
+    "pricing": [
+      "poa",
+      "recurring",
+      "high"
+    ],
+    "saas": false,
+    "website": "https://doc.sitecore.com/xp/en/developers/101/developer-tools/experience-edge-for-xm-apis.html"
+  },
+  "Sitecore Experience Platform": {
+    "cats": [
+      1
+    ],
+    "description": "Sitecore Experience Platform is a digital platform used by businesses to create, manage, and deliver personalised content and experiences to users across different channels.",
+    "icon": "Sitecore.svg",
+    "pricing": [
+      "poa",
+      "recurring",
+      "high"
+    ],
+    "saas": true,
+    "website": "https://www.sitecore.com/products/sitecore-experience-platform"
+  },
   "Siteglide": {
     "cats": [
       1,


### PR DESCRIPTION
### website
https://www.sitecore.com/products/sitecore-experience-platform
https://doc.sitecore.com/xp/en/developers/101/developer-tools/experience-edge-for-xm-apis.html
### example:
https://www.atkore.com/Resources
https://www.kennards.com.au/
https://www.kennardshire.co.nz/

Distinguished from the core cms Sitecore as I'm not sure what the platform is supposed to be
`"implies": "Microsoft ASP.NET",`